### PR TITLE
Fix setup.py crash by updating some versions and adding marionette_client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setup(name='SeleniumProxy',
                   'Programming Language :: Python'],
       py_modules=['selenium_proxy'],
       # TODO(David) add Marionette when that is up on Pypi
-      install_requires=["mozrunner==5.2","mozprofile==0.2", "selenium"]
+      install_requires=["mozrunner==5.15","mozprofile==0.7", "selenium",
+                        "marionette_client"]
       )


### PR DESCRIPTION
For some reason, nailing down the marionette_client version to 0.5.27 caused a different exception.  But this patch should be good enough to get things started.  Note, though, that I've only tested that "python setup.py install" actually works, and I've only tested it under virtualenv.  But this is a step in the right direction, I think.
